### PR TITLE
feat: add eta parameter for sign-changing correlation energy

### DIFF
--- a/NN_models.py
+++ b/NN_models.py
@@ -41,6 +41,25 @@ true_constants_PBE = torch.Tensor(
     ]
 ).to(device)
 
+# Расширенная версия с 27 параметрами (оригинальные 26 + новый eta)
+true_constants_PBE_extended = torch.Tensor([
+    [
+        0.06672455,           # 0: mbeta
+        (1 - torch.log(torch.Tensor([2]))) / (np.pi**2),  # 1: mgamma
+        1.709921,              # 2: fz20
+        7.5957, 14.1189, 10.357,  # 3-5: params_a_beta1
+        3.5876, 6.1977, 3.6231,   # 6-8: params_a_beta2  
+        1.6382, 3.3662, 0.88026,  # 9-11: params_a_beta3
+        0.49294, 0.62517, 0.49671, # 12-14: params_a_beta4
+        0.031091, 0.015545, 0.016887,  # 15-17: params_a_a
+        0.21370, 0.20548, 0.11125,     # 18-20: params_a_alpha1
+        -3/8*(3/np.pi)**(1/3)*4**(2/3), # 21: LDA_X_FACTOR
+        0.8040, 0.2195149727645171,     # 22-23: kappa, mu
+        0.8040, 0.2195149727645171,     # 24-25: дублирование
+        1.0  # 26: НОВЫЙ ПАРАМЕТР eta (начальное значение)
+    ]
+]).to(device)
+
 sigmoid = torch.nn.Sigmoid()
 elu = torch.nn.ELU()
 
@@ -153,7 +172,7 @@ class MLOptimizer(nn.Module):
 
 class pcPBEMLOptimizer(nn.Module):
     def __init__(
-        self, num_layers, h_dim, nconstants_x=2, nconstants_c=2, dropout=0.2, DFT=None
+        self, num_layers, h_dim, nconstants_x=2, nconstants_c=3, dropout=0.2, DFT=None ###было nconstants_c=2
     ):
         super().__init__()
 
@@ -214,13 +233,21 @@ class pcPBEMLOptimizer(nn.Module):
             x_x_down[:, 1].view(-1, 1),
             x_x_down[:, 0].view(-1, 1),
         )
-
+    
     def get_correlation_constants(self, x):
-
         x_c = self.hidden_layers_c(x)
+        # Теперь возвращаем 3 параметра: beta, gamma, eta, отвечающая за положительность корреляционной 
+        return x_c[:, 0].view(-1, 1), x_c[:, 1].view(-1, 1), x_c[:, 2].view(-1, 1)
+    # def get_correlation_constants(self, x):
 
-        return x_c[:, 0].view(-1, 1), x_c[:, 1].view(-1, 1)
+    #     x_c = self.hidden_layers_c(x)
 
+    #     return x_c[:, 0].view(-1, 1), x_c[:, 1].view(-1, 1)
+    def eta_activation(self, x): ### зачем этот диапазон нужен и активация для эты - хз, нейронка явно знает лучше
+        """
+        Активация для eta: переводит в диапазон [0.5, 3.0]
+        """
+        return 0.5 + 2.5 * torch.sigmoid(x)
     @staticmethod
     def all_sigma_zero(x):
         """
@@ -259,10 +286,11 @@ class pcPBEMLOptimizer(nn.Module):
 
         mu_up, kappa_up, mu_down, kappa_down = self.get_exchange_constants(x)
 
-        beta, gamma = self.get_correlation_constants(x)
+        beta, gamma, eta_raw = self.get_correlation_constants(x) ###3 параметра а не 2
 
         beta = self.beta_activation((beta - self.get_correlation_constants(self.all_sigma_zero_beta(x))[0]).view(-1,1))
         gamma = self.shifted_elu((gamma - self.get_correlation_constants(self.all_rho_inf(x))[1]).view(-1,1))
+        eta = self.eta_activation(eta_raw)  # Активируем eta Я не уверен, что без view(-1,1) будет правильно, но посмотрим
         mu_up = self.shifted_elu((mu_up - self.get_exchange_constants(self.all_sigma_zero(x))[0])).view(-1,1)
         mu_down = self.shifted_elu((mu_down - self.get_exchange_constants(self.all_sigma_zero(x))[2])).view(-1,1)
         kappa_up = self.kappa_activation(kappa_up).view(-1,1)
@@ -277,5 +305,6 @@ class pcPBEMLOptimizer(nn.Module):
                 mu_up,
                 kappa_down,
                 mu_down,
+                eta,  # ДОБАВЛЯЕМ НОВЫЙ ПАРАМЕТР (индекс 26)
             ]
-        ) * true_constants_PBE.to(x.device)
+        ) * true_constants_PBE_extended.to(x.device) # Используем расширенную версию

--- a/dft_functionals/PBE.py
+++ b/dft_functionals/PBE.py
@@ -253,3 +253,38 @@ def pw_test(rho, c_arr):
     pw_energy = f_pw(rs, z, c_arr)
     catch_nan(pw_energy=pw_energy)
     return pw_energy
+
+def f2_different(rs, z, t, c_arr, device):
+    A_ = A(rs, z, t, c_arr, device)
+    f1_ = f1(rs, z, t, A_, c_arr)
+    # Используем новый параметр eta = c_arr[:, 26]
+    denominator = c_arr[:, 1] * (A_ * f1_ - c_arr[:, 26] + 1) ###идея в том, чтобы eta (c_arr[:, 26]) меняла знак деноминатора, от чего изменится fH->PBE_C станет знаконеопределенной
+    # Защита от численных особенностей
+    denominator = torch.where(torch.abs(denominator) < 1e-12, 
+                             torch.sign(denominator) * 1e-12, denominator)
+    res_f2 = c_arr[:, 0] * f1_ / denominator
+    catch_nan(res_f2=res_f2, f1_=f1_, A_=A_)
+    return res_f2
+
+def fH_different(rs, z, t, c_arr, device):
+    eps = 1e-8
+    f2_ = f2_different(rs, z, t, c_arr, device)
+    log = torch.where(
+        f2_ <= -1 + eps, torch.log1p(f2_ + eps), torch.log1p(f2_)
+    )
+    res_fH = c_arr[:, 1] * mphi(z) ** 3 * log
+    catch_nan(res_fH=res_fH, log=log, f2_=f2_)
+    return res_fH
+
+def PBE_C_different(rs, z, xt, c_arr, device):
+    res_PBE_C = f_pw(rs, z, c_arr) + fH_different(rs, z, tt(rs, z, xt), c_arr, device)
+    catch_nan(res_PBE_C=res_PBE_C)
+    return res_PBE_C
+
+def F_PBE_different(rho, sigmas, c_arr, device):
+    catch_nan(rho=rho, sigmas=sigmas, c_arr=c_arr)
+    rs, z = rs_z_calc(rho)
+    xs0, xs1, xt = xs_xt_calc(rho, sigmas)
+    res_energy = PBE_X(rs, z, xt, xs0, xs1, c_arr) + PBE_C_different(rs, z, xt, c_arr, device)
+    catch_nan(res_energy=res_energy)
+    return res_energy

--- a/predopt.py
+++ b/predopt.py
@@ -59,6 +59,7 @@ true_constants_PBE = torch.Tensor(
             0.2195149727645171,
             0.8040,
             0.2195149727645171,
+            1.0
         ]
     ]
 )
@@ -107,9 +108,9 @@ def predopt(
             y_batch = torch.tile(y_batch, [X_batch.shape[0], 1]).to(
                 device, non_blocking=True
             )[
-                :, [0, 1, 22, 23, 24, 25]
+                :, [0, 1, 22, 23, 24, 25, 26] # ДОБАВИЛИ ИНДЕКС 26
             ]  # If PBE
-            predictions = model(X_batch)[:, [0, 1, 22, 23, 24, 25]]  # if PBE
+            predictions = model(X_batch)[:, [0, 1, 22, 23, 24, 25, 26]]  # if PBE # ДОБАВИЛИ ИНДЕКС 26
 
             loss = criterion(predictions, y_batch)
             loss.backward()

--- a/reaction_energy_calculation.py
+++ b/reaction_energy_calculation.py
@@ -3,7 +3,20 @@ import torch
 
 from dft_functionals.PBE import F_PBE
 from dft_functionals.SVWN3 import F_XALPHA, f_svwn3
+from dft_functionals.PBE import F_PBE_different
 
+def get_local_energies_different(reaction, constants, device, rung="GGA", dft="PBE"): ###потому что появился F_PBE_different
+    calc_reaction_data = {}
+    densities = reaction["Densities"].to(device)
+    if rung == "GGA":
+        gradients = (reaction["Gradients"]).to(device)
+        if dft == "PBE":
+            local_energies = F_PBE_different(densities, gradients, constants, device)
+    
+    calc_reaction_data["Local_energies"] = local_energies
+    calc_reaction_data["Densities"] = densities
+    calc_reaction_data["Weights"] = reaction["Weights"].to(device)
+    return calc_reaction_data
 
 def get_local_energies(reaction, constants, device, rung="GGA", dft="PBE"):
     calc_reaction_data = {}
@@ -81,7 +94,7 @@ def get_energy_reaction(reaction, molecule_energies):
 def calculate_reaction_energy(
     reaction, constants, device, rung, dft, dispersions=dict()
 ):
-    local_energies = get_local_energies(reaction, constants, device, rung, dft)
+    local_energies = get_local_energies_different(reaction, constants, device, rung, dft) ###изменили формулу взятия локальных энергий
     if local_energies["Local_energies"].isnan().any():
         print(local_energies["Local_energies"].isnan().sum())
         torch.save(local_energies["Local_energies"], "local_energies.pt")


### PR DESCRIPTION
- Modified pcPBEMLOptimizer to predict eta parameter (index 26)
- Added new activation functions for eta
- Extended true_constants_PBE to include initial eta value
- Implemented PBE_C_different with sign-changing capability
- Updated training indices in predopt.py
- Added alternative energy calculation function